### PR TITLE
Proving Schedule interface

### DIFF
--- a/src/IPDPProvingSchedule.sol
+++ b/src/IPDPProvingSchedule.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+/// @title IPDPProvingWindow
+/// @notice Interface for PDP Service SLA specifications
+interface IPDPProvingSchedule {
+    /// @notice Returns the number of epochs allowed before challenges must be resampled
+    /// @return Maximum proving period in epochs
+    function getMaxProvingPeriod() external pure returns (uint64);
+
+    /// @notice Returns the number of epochs at the end of a proving period during which proofs can be submitted
+    /// @return Challenge window size in epochs
+    function challengeWindow() external pure returns (uint256);
+
+    /// @notice Calculates the start of the next challenge window for a given proof set
+    /// @param setId The ID of the proof set
+    /// @return The block number when the next challenge window starts
+    function nextChallengeWindowStart(uint256 setId) external view returns (uint256);
+
+    /// @notice Returns the required number of challenges/merkle inclusion proofs per proof set
+    /// @return Number of challenges required per proof
+    function getChallengesPerProof() external pure returns (uint64);
+}

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -174,6 +174,12 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         return nextChallengeEpoch[setId];
     }
 
+    // Returns the listener address for a proof set
+    function getProofSetListener(uint256 setId) public view returns (address) {
+        require(proofSetLive(setId), "Proof set not live");
+        return proofSetListener[setId];
+    }
+
     // Returns the owner of a proof set and the proposed owner if any
     function getProofSetOwner(uint256 setId) public view returns (address, address) {
         require(proofSetLive(setId), "Proof set not live");


### PR DESCRIPTION
This makes it easier for curio or other SP tools to consume standard proving window meta data that is likely to be standard across listeners.  See integration into curio [here](https://github.com/filecoin-project/curio/pull/334)