### PR TITLE
Remove special casing of first add

### DIFF
--- a/src/IPDPProvingSchedule.sol
+++ b/src/IPDPProvingSchedule.sol
@@ -12,6 +12,11 @@ interface IPDPProvingSchedule {
     /// @return Challenge window size in epochs
     function challengeWindow() external pure returns (uint256);
 
+    /// @notice Value for initializing the challenge window start for a given proof set assuming proving period starts now
+    // @return Initial challenge window start in epochs
+    function initChallengeWindowStart(uint256 setId) external pure returns (uint256);
+
+
     /// @notice Calculates the start of the next challenge window for a given proof set
     /// @param setId The ID of the proof set
     /// @return The block number when the next challenge window starts

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -477,6 +477,11 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     function nextProvingPeriod(uint256 setId, uint256 challengeEpoch, bytes calldata extraData) public {
         require(extraData.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
         require(msg.sender == proofSetOwner[setId], "only the owner can move to next proving period");
+        
+        if (proofSetLastProvenEpoch[setId] == NO_PROVEN_EPOCH) {
+            proofSetLastProvenEpoch[setId] = block.number;
+        }
+
         // Take removed roots out of proving set
         uint256[] storage removals = scheduledRemovals[setId];
         uint256[] memory removalsToProcess = new uint256[](removals.length);

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -385,8 +385,7 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         require(block.number >= challengeEpoch, "premature proof");
         require(proofs.length > 0, "empty proof");
         require(challengeEpoch != NO_CHALLENGE_SCHEDULED, "no challenge scheduled");
-        require(proofSetOwner[setId] == msg.sender, "only the owner can prove possession");
-
+        
         uint256 seed = drawChallengeSeed(setId);
         uint256 leafCount = challengeRange[setId];
         uint256 sumTreeTop = 256 - BitOps.clz(nextRootId[setId]);

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -912,7 +912,7 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
         
         PDPVerifier.Proof[] memory proofs = buildProofsForSingleton(setId, 5, tree, 10);
         vm.mockCall(pdpVerifier.RANDOMNESS_PRECOMPILE(), abi.encode(nearerBlock), abi.encode(nearerBlock));
-        pdpVerifier.provePossession{value: PDPFees.proofFee(proofs.length)}(setId, proofs);
+        pdpVerifier.provePossession{value: 1e18}(setId, proofs);
     }
 
 

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -256,6 +256,7 @@ contract PDPVerifierProofSetMutateTest is Test {
         PDPVerifier.RootData[] memory roots = new PDPVerifier.RootData[](1);
         roots[0] = PDPVerifier.RootData(Cids.Cid(abi.encodePacked("test")), 64);
         uint256 rootId = pdpVerifier.addRoots(setId, roots, empty);
+        assertEq(pdpVerifier.getChallengeRange(setId), 0);
         listenerAssert.expectEvent(PDPRecordKeeper.OperationType.ADD, setId);
         // flush add
         pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinalityDelay, empty);
@@ -363,7 +364,11 @@ contract PDPVerifierProofSetMutateTest is Test {
         roots[0] = PDPVerifier.RootData(Cids.Cid(abi.encodePacked("test")), 64);
         pdpVerifier.addRoots(setId, roots, empty);
         listenerAssert.expectEvent(PDPRecordKeeper.OperationType.ADD, setId);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), pdpVerifier.NO_CHALLENGE_SCHEDULED()); // Not updated on first add anymore
+        pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinalityDelay, empty);
+        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
         assertEq(pdpVerifier.getNextChallengeEpoch(setId), block.number + challengeFinalityDelay);
+        
 
         // Remove root
         uint256[] memory toRemove = new uint256[](1);
@@ -374,7 +379,7 @@ contract PDPVerifierProofSetMutateTest is Test {
         pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinalityDelay, empty); // flush
         listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
 
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), 0);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), pdpVerifier.NO_CHALLENGE_SCHEDULED());
         assertEq(pdpVerifier.rootLive(setId, 0), false);
         assertEq(pdpVerifier.getNextRootId(setId), 1);
         assertEq(pdpVerifier.getProofSetLeafCount(setId), 0);
@@ -462,6 +467,32 @@ contract PDPVerifierProofSetMutateTest is Test {
 
         assertEq(false, pdpVerifier.rootLive(setId, 0));
         assertEq(false, pdpVerifier.rootLive(setId, 1));
+    }
+
+    function testNextProvingPeriodWithNoData() public {
+        // Get the NO_CHALLENGE_SCHEDULED constant value for clarity
+        uint256 NO_CHALLENGE = pdpVerifier.NO_CHALLENGE_SCHEDULED();
+        
+        uint256 setId = pdpVerifier.createProofSet{value: PDPFees.sybilFee()}(address(listener), empty);
+        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.CREATE, setId);
+        
+        // Initial state should be NO_CHALLENGE
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Initial state should be NO_CHALLENGE");
+        
+        // Try to set next proving period with various values
+        pdpVerifier.nextProvingPeriod(setId, block.number + 100, empty);
+        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Should remain NO_CHALLENGE after setting future block");
+        
+        pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinalityDelay, empty);
+        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Should remain NO_CHALLENGE after setting zero");
+        
+        pdpVerifier.nextProvingPeriod(setId, type(uint256).max, empty);
+        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Should remain NO_CHALLENGE after setting max uint");
+        
+        tearDown();
     }
 }
 
@@ -859,6 +890,29 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
         pdpVerifier.provePossession{value: 1e18}(setId, proofs);
         listenerAssert.expectEvent(PDPRecordKeeper.OperationType.PROVE_POSSESSION, setId);
         tearDown();
+    }
+
+    function testNextProvingPeriodFlexibleScheduling() public {
+        // Create proof set and add initial root
+        uint leafCount = 10;
+        (uint256 setId, bytes32[][] memory tree) = makeProofSetWithOneRoot(leafCount);
+
+        // Set challenge sampling far in the future
+        uint256 farFutureBlock = block.number + 1000;
+        pdpVerifier.nextProvingPeriod(setId, farFutureBlock, empty);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), farFutureBlock, "Challenge epoch should be set to far future");
+
+        // Reset to a closer block
+        uint256 nearerBlock = block.number + challengeFinalityDelay;
+        pdpVerifier.nextProvingPeriod(setId, nearerBlock, empty);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), nearerBlock, "Challenge epoch should be reset to nearer block");
+
+        // Verify we can still prove possession at the new block
+        vm.roll(nearerBlock);
+        
+        PDPVerifier.Proof[] memory proofs = buildProofsForSingleton(setId, 5, tree, 10);
+        vm.mockCall(pdpVerifier.RANDOMNESS_PRECOMPILE(), abi.encode(nearerBlock), abi.encode(nearerBlock));
+        pdpVerifier.provePossession{value: PDPFees.proofFee(proofs.length)}(setId, proofs);
     }
 
 
@@ -1490,6 +1544,8 @@ contract PDPVerifierE2ETest is Test, ProofBuilderHelper {
         rootsPP1[0] = PDPVerifier.RootData(Cids.cidFromDigest("test1", treesA[0][0][0]), leafCountsA[0] * 32);
         rootsPP1[1] = PDPVerifier.RootData(Cids.cidFromDigest("test2", treesA[1][0][0]), leafCountsA[1] * 32);
         pdpVerifier.addRoots(setId, rootsPP1, empty);
+        // flush the original addRoots call
+        pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinalityDelay, empty);
 
         uint256 challengeRangePP1 = pdpVerifier.getChallengeRange(setId);
         assertEq(challengeRangePP1, pdpVerifier.getProofSetLeafCount(setId), "Last challenged leaf should be total leaf count - 1");

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -480,17 +480,14 @@ contract PDPVerifierProofSetMutateTest is Test {
         assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Initial state should be NO_CHALLENGE");
         
         // Try to set next proving period with various values
+        vm.expectRevert("can only start proving once leaves are added");
         pdpVerifier.nextProvingPeriod(setId, block.number + 100, empty);
-        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Should remain NO_CHALLENGE after setting future block");
         
+        vm.expectRevert("can only start proving once leaves are added");
         pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinalityDelay, empty);
-        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Should remain NO_CHALLENGE after setting zero");
-        
+
+        vm.expectRevert("can only start proving once leaves are added");
         pdpVerifier.nextProvingPeriod(setId, type(uint256).max, empty);
-        listenerAssert.expectEvent(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD, setId);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), NO_CHALLENGE, "Should remain NO_CHALLENGE after setting max uint");
         
         tearDown();
     }

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
 import {Test, console} from "forge-std/Test.sol";
@@ -490,6 +491,20 @@ contract PDPVerifierProofSetMutateTest is Test {
         pdpVerifier.nextProvingPeriod(setId, type(uint256).max, empty);
         
         tearDown();
+    }
+    
+    function testNextProvingPeriodRevertsOnEmptyProofSet() public {
+        // Create a new proof set
+        uint256 setId = pdpVerifier.createProofSet{value: PDPFees.sybilFee()}(address(listener), empty);
+        
+        // Try to call nextProvingPeriod on the empty proof set
+        // Should revert because no leaves have been added yet
+        vm.expectRevert("can only start proving once leaves are added");
+        pdpVerifier.nextProvingPeriod(
+            setId,
+            block.number + challengeFinalityDelay,
+            empty
+        );
     }
 }
 
@@ -1016,9 +1031,6 @@ contract SumTreeHeightTest is Test {
         }
     }
 }
-
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 import "../src/PDPVerifier.sol";

--- a/test/SimplePDPService.t.sol
+++ b/test/SimplePDPService.t.sol
@@ -127,7 +127,7 @@ contract SimplePDPServiceTest is Test {
         pdpService.nextProvingPeriod(proofSetId, pdpService.initChallengeWindowStart(), leafCount, empty);
         
         // Prove possession in first period
-        vm.roll(block.number + pdpService.getMaxProvingPeriod() - 100);
+        vm.roll(block.number + pdpService.getMaxProvingPeriod() - pdpService.challengeWindow());
         pdpService.possessionProven(proofSetId, leafCount, seed, 5);
         
         // Inactivate the proof set
@@ -171,12 +171,12 @@ contract SimplePDPServiceFaultsTest is Test {
         // Set up the proving deadline
         pdpService.rootsAdded(proofSetId, 0, new PDPVerifier.RootData[](0), empty);
         pdpService.nextProvingPeriod(proofSetId, pdpService.initChallengeWindowStart(), leafCount, empty);
-        vm.roll(block.number + pdpService.getMaxProvingPeriod());
+        vm.roll(block.number + pdpService.getMaxProvingPeriod() - pdpService.challengeWindow());
         pdpService.possessionProven(proofSetId, leafCount, seed, challengeCount);
         assertTrue(pdpService.provenThisPeriod(proofSetId));
 
         pdpService.nextProvingPeriod(proofSetId, pdpService.nextChallengeWindowStart(proofSetId), leafCount, empty);
-        vm.roll(block.number + 1);
+        vm.roll(block.number + pdpService.getMaxProvingPeriod());
         pdpService.possessionProven(proofSetId, leafCount, seed, challengeCount);
     }
 
@@ -325,7 +325,7 @@ contract SimplePDPServiceFaultsTest is Test {
         vm.roll(block.number + pdpService.getMaxProvingPeriod() - pdpService.challengeWindow());
         pdpService.possessionProven(proofSetId, leafCount, seed, 5);
         pdpService.nextProvingPeriod(proofSetId, pdpService.nextChallengeWindowStart(proofSetId), leafCount, empty);
-        vm.expectRevert("Too early. Wait for challenge windowto open");
+        vm.expectRevert("Too early. Wait for challenge window to open");
         pdpService.possessionProven(proofSetId, leafCount, seed, 5);
     }
 


### PR DESCRIPTION
Closes #

- [x] Remove special casing of first add
- [x] Handle first add in next proving period 
- [x] Update PDP service to support this behavior
- [x] Update deadline calculator functions to return useful values when state not yet initialized
- [x] Support graceful stopping of PDP Service accounting when all roots are removed