### PR TITLE
Update makefile to use script compatible env var names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Variables
 RPC_URL ?=
-KEYSTORE_PATH ?=
+KEYSTORE ?=
 PASSWORD ?=
 CHALLENGE_FINALITY ?=
 


### PR DESCRIPTION
Either `forge` or lotus eth api recently updated to some sort of terrible behavior where nonce tracking no longer works so I implement this in the script itself.