### PR TITLE
Audit 3.3 and 3.4 -- fix refund issues

### DIFF
--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -275,10 +275,7 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         uint256 sybilFee = PDPFees.sybilFee();
         require(msg.value >= sybilFee, "sybil fee not met");
         burnFee(sybilFee);
-        if (msg.value > sybilFee) {
-            // Return the overpayment
-            payable(msg.sender).transfer(msg.value - sybilFee);
-        }
+
 
         uint256 setId = nextProofSetId++;
         proofSetLeafCount[setId] = 0;
@@ -291,6 +288,10 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
             PDPListener(listenerAddr).proofSetCreated(setId, msg.sender, extraData);
         }
         emit ProofSetCreated(setId, msg.sender);
+        if (msg.value > sybilFee) {
+            // Return the overpayment
+            payable(msg.sender).transfer(msg.value - sybilFee);
+        }
         return setId;
     }
 

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -290,7 +290,8 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         emit ProofSetCreated(setId, msg.sender);
         if (msg.value > sybilFee) {
             // Return the overpayment
-            payable(msg.sender).transfer(msg.value - sybilFee);
+            (bool success, ) = msg.sender.call{value: msg.value - sybilFee}("");
+            require(success, "Transfer failed.");
         }
         return setId;
     }
@@ -448,7 +449,8 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         proofSetLastProvenEpoch[setId] = block.number;
         emit PossessionProven(setId, challenges);
         if (refund > 0) {
-            payable(msg.sender).transfer(refund);
+            (bool success, ) = msg.sender.call{value: refund}("");
+            require(success, "Transfer failed.");
         }
     }
 


### PR DESCRIPTION
This addresses the audit review for items 3.3 and 3.4 

3.3 
The audit notes that transfers have issues interacting with smart wallet / more sophisticated sending contracts.  A large reason for this is that transfer puts a very restricted limit on gas usage in the transfer function.   This is a blanket reentrency protection that we don't need.  So this PR forwards full gas limit to the transfer to maximize sending contract compatibility (commit `d6b0a639581839eb2fabdf6b3f368f6a372ac6bd`)

3.4
The audit notes that there is a reentrancy issue since the prove possession transfer is not matching the standard Checks Effects Interactions pattern.  To rememdy this we move the refund call to the end of the `provePossession` call (`70dbb0e839220803fe724ef498cc594256110324`).  We do the same for proofSetCreation (`4b04bc08ceae4fa45775556328eaddf1a27ff6de`).