### PR TITLE
Actually check proof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ install:
 # Build target
 .PHONY: build
 build:
-	forge build
+	forge build --via-ir
 
 # Test target
 .PHONY: test
 test:
-	forge test -vv
+	forge test --via-ir -vv
 
 # Deployment targets
 .PHONY: deploy-calibnet

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -59,8 +59,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
     // Types
     // State fields
-     event Debug(string message, uint256 value);
-
     /*
     A proof set is the metadata required for tracking data for proof of possession.
     It maintains a list of CIDs of data to be proven and metadata needed to

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -436,6 +436,8 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
                 // Find the root that has this leaf, and the offset of the leaf within that root.
                 challenges[i] = findOneRootId(setId, challengeIdx, sumTreeTop);
                 bytes32 rootHash = Cids.digestFromCid(getRootCid(setId, challenges[i].rootId));
+                uint256 levels = 256 - BitOps.clz(rootLeafCounts[setId][challenges[i].rootId]);
+                require(proofs[i].proof.length == levels, "proof length does not match root height");
                 bool ok = MerkleVerify.verify(proofs[i].proof, rootHash, proofs[i].leaf, challenges[i].offset);
                 require(ok, "proof did not verify");
             }

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -428,7 +428,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
                 // To remove this deviation we could use the standard solution of rejection sampling
                 //   This is complicated and slightly more costly at one more hash on average for maximally misaligned proofsets
                 //   and comes at no practical benefit given how small the deviation is.
-               {
                 bytes memory payload = abi.encodePacked(seed, setId, i);
                 uint256 challengeIdx = uint256(keccak256(payload)) % leafCount;
 
@@ -438,7 +437,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
                 uint256 rootHeight = 256 - BitOps.clz(rootLeafCounts[setId][challenges[i].rootId] - 1) + 1;
                 bool ok = MerkleVerify.verify(proofs[i].proof, rootHash, proofs[i].leaf, challenges[i].offset, rootHeight);
                 require(ok, "proof did not verify");
-               }
             }
         }
 

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -430,16 +430,17 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
                 // To remove this deviation we could use the standard solution of rejection sampling
                 //   This is complicated and slightly more costly at one more hash on average for maximally misaligned proofsets
                 //   and comes at no practical benefit given how small the deviation is.
+               {
                 bytes memory payload = abi.encodePacked(seed, setId, i);
                 uint256 challengeIdx = uint256(keccak256(payload)) % leafCount;
 
                 // Find the root that has this leaf, and the offset of the leaf within that root.
                 challenges[i] = findOneRootId(setId, challengeIdx, sumTreeTop);
                 bytes32 rootHash = Cids.digestFromCid(getRootCid(setId, challenges[i].rootId));
-                uint256 levels = 256 - BitOps.clz(rootLeafCounts[setId][challenges[i].rootId]);
-                require(proofs[i].proof.length == levels, "proof length does not match root height");
-                bool ok = MerkleVerify.verify(proofs[i].proof, rootHash, proofs[i].leaf, challenges[i].offset);
+                uint256 rootHeight = 256 - BitOps.clz(rootLeafCounts[setId][challenges[i].rootId] - 1) + 1;
+                bool ok = MerkleVerify.verify(proofs[i].proof, rootHash, proofs[i].leaf, challenges[i].offset, rootHeight);
                 require(ok, "proof did not verify");
+               }
             }
         }
 

--- a/src/Proofs.sol
+++ b/src/Proofs.sol
@@ -19,20 +19,24 @@ library MerkleVerify {
      * defined by `root` at `position`. For this, a `proof` must be provided, containing
      * sibling hashes on the branch from the leaf to the root of the tree.
      *
+     * Will only return true if the leaf is at the bottom of the tree for the given tree height
+     *
      * This version handles proofs in memory.
      */
-    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf, uint256 position) internal view returns (bool) {
-        return processProofMemory(proof, leaf, position) == root;
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf, uint256 position, uint256 treeHeight) internal view returns (bool) {
+        // Tree heigh includes root, proof does not 
+        require(proof.length == treeHeight - 1, "proof length does not match tree height");
+        return processInclusionProofMemory(proof, leaf, position) == root;
     }
 
     /**
      * Returns the rebuilt hash obtained by traversing a Merkle tree up
      * from `leaf` at `position` using `proof`. A `proof` is valid if and only if the rebuilt
-     * hash matches the root of the tree.
+     * hash matches the root of the tree.  
      *
      * This version handles proofs in memory.
      */
-    function processProofMemory(bytes32[] memory proof, bytes32 leaf, uint256 position) internal view returns (bytes32) {
+    function processInclusionProofMemory(bytes32[] memory proof, bytes32 leaf, uint256 position) internal view returns (bytes32) {
         bytes32 computedHash = leaf;
         for (uint256 i = 0; i < proof.length; i++) {
             // If position is even, the leaf/node is on the left and sibling is on the right.
@@ -147,7 +151,7 @@ library MerkleProve {
 
     // Gets an inclusion proof from a Merkle tree for a leaf at a given index.
     // The proof is constructed by traversing up the tree to the root, and the sibling of each node is appended to the proof.
-    // A final unpaired element in any level is paired with itself.
+    // A final unpaired element in any level is paired with the zero-tree of the same height.
     // Every proof thus has length equal to the height of the tree minus 1.
     function buildProof(bytes32[][] memory tree, uint256 index) internal pure returns (bytes32[] memory) {
         require(index < tree[tree.length - 1].length, "Index out of bounds");

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -805,6 +805,7 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
     }
 
     receive() external payable {}
+        event Debug(string message, uint256 value);
 
     function testProveWithDifferentFeeAmounts() public {
         // Mock Pyth oracle call to return $5 USD/FIL
@@ -840,6 +841,9 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
             pdpVerifier.provePossession{value: sender.balance}(setId, proofs);
             uint256 balanceAfter = sender.balance;
             correctFee = balanceBefore - balanceAfter;
+            emit Debug("balanceBefore", balanceBefore);
+            emit Debug("balanceAfter", balanceAfter);
+            emit Debug("correctFee", correctFee);
             vm.revertToStateAndDelete(snapshotId);
         }
 

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -808,6 +808,7 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
         event Debug(string message, uint256 value);
 
     function testProveWithDifferentFeeAmounts() public {
+        vm.fee(0 gwei);
         // Mock Pyth oracle call to return $5 USD/FIL
         (bytes memory pythCallData, PythStructs.Price memory price) = createPythCallData();
         price.price = 1;

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -842,9 +842,6 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
             pdpVerifier.provePossession{value: sender.balance}(setId, proofs);
             uint256 balanceAfter = sender.balance;
             correctFee = balanceBefore - balanceAfter;
-            emit Debug("balanceBefore", balanceBefore);
-            emit Debug("balanceAfter", balanceAfter);
-            emit Debug("correctFee", correctFee);
             vm.revertToStateAndDelete(snapshotId);
         }
 

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -1095,6 +1095,35 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper {
     }
 
 
+    function testProveSingleFake() public {
+        // Mock Pyth oracle call to return $5 USD/FIL
+        (bytes memory pythCallData, PythStructs.Price memory price) = createPythCallData();
+        vm.mockCall(address(pdpVerifier.PYTH()), pythCallData, abi.encode(price));
+
+        uint leafCount = 10;
+        (uint256 setId, bytes32[][] memory tree) = makeProofSetWithOneRoot(leafCount);
+
+        // Advance chain until challenge epoch.
+        uint256 challengeEpoch = pdpVerifier.getNextChallengeEpoch(setId);
+        vm.roll(challengeEpoch);
+
+        uint challengeCount = 3;
+        // build fake proofs
+        PDPVerifier.Proof[] memory proofs = new PDPVerifier.Proof[](5);
+        for (uint i = 0; i < 5; i++) {
+            proofs[i] = PDPVerifier.Proof(tree[0][0], new bytes32[](0));
+        }
+
+        // Submit proof.
+        vm.mockCall(pdpVerifier.RANDOMNESS_PRECOMPILE(), abi.encode(challengeEpoch), abi.encode(challengeEpoch));
+        PDPVerifier.RootIdAndOffset[] memory challenges = new PDPVerifier.RootIdAndOffset[](challengeCount);
+        for (uint i = 0; i < challengeCount; i++) {
+            challenges[i] = PDPVerifier.RootIdAndOffset(0, 0);
+        }
+        vm.expectRevert("proof length does not match tree height");
+        pdpVerifier.provePossession{value: 1e18}(setId, proofs);
+    }
+
     ///// Helpers /////
 
     // Initializes a new proof set, generates trees of specified sizes, and adds roots to the set.


### PR DESCRIPTION
As reported by @Kubuxu the contract does not currently check that inclusion proofs go down to the leaves.  So it is currently trivial to always get a valid proof by submitting the root as a leaf and an empty array of siblings as a proof. 
 This PR fixes this by adding tree height into the inclusion proof verification library.