### PR TITLE
feat: allow provider to set it's beneficiary address in PDP Verifier so all service contracts can get access to it

### DIFF
--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -13,7 +13,7 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
 /// @title PDPListener
 /// @notice Interface for PDP Service applications managing data storage.
-/// @dev This interface exists to provide an extensible hook for applic ations to use the PDP verification contract
+/// @dev This interface exists to provide an extensible hook for applications to use the PDP verification contract
 /// to implement data storage applications.
 interface PDPListener {
     function proofSetCreated(uint256 proofSetId, address creator, address beneficiary, bytes calldata extraData) external;

--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -13,7 +13,7 @@ import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
 /// @title PDPListener
 /// @notice Interface for PDP Service applications managing data storage.
-/// @dev This interface exists to provide an extensible hook for applications to use the PDP verification contract
+/// @dev This interface exists to provide an extensible hook for applic ations to use the PDP verification contract
 /// to implement data storage applications.
 interface PDPListener {
     function proofSetCreated(uint256 proofSetId, address creator, address beneficiary, bytes calldata extraData) external;
@@ -60,7 +60,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
     // Types
     // State fields
-     event Debug(string message, uint256 value);
 
     /*
     A proof set is the metadata required for tracking data for proof of possession.
@@ -313,7 +312,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         proofSetLastProvenEpoch[setId] = NO_PROVEN_EPOCH;
 
         if (listenerAddr != address(0)) {
-            // Pass the beneficiary address to the listener
             PDPListener(listenerAddr).proofSetCreated(setId, msg.sender, beneficiary, extraData);
         }
         
@@ -467,7 +465,8 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
                 // Find the root that has this leaf, and the offset of the leaf within that root.
                 challenges[i] = findOneRootId(setId, challengeIdx, sumTreeTop);
                 bytes32 rootHash = Cids.digestFromCid(getRootCid(setId, challenges[i].rootId));
-                bool ok = MerkleVerify.verify(proofs[i].proof, rootHash, proofs[i].leaf, challenges[i].offset);
+                uint256 rootHeight = 256 - BitOps.clz(rootLeafCounts[setId][challenges[i].rootId] - 1) + 1;
+                bool ok = MerkleVerify.verify(proofs[i].proof, rootHash, proofs[i].leaf, challenges[i].offset, rootHeight);
                 require(ok, "proof did not verify");
             }
         }

--- a/src/SimplePDPService.sol
+++ b/src/SimplePDPService.sol
@@ -164,7 +164,7 @@ contract SimplePDPService is PDPListener, Initializable, UUPSUpgradeable, Ownabl
     // Note many of these are noops as they are not important for the SimplePDPService's functionality
     // of enforcing proof contraints and reporting faults.
     // Note we generally just drop the user defined extraData as this contract has no use for it
-    function proofSetCreated(uint256 proofSetId, address creator, bytes calldata) external onlyPDPVerifier {}
+    function proofSetCreated(uint256 proofSetId, address creator, address beneficiary, bytes calldata) external onlyPDPVerifier {}
 
     function proofSetDeleted(uint256 proofSetId, uint256 deletedLeafCount, bytes calldata) external onlyPDPVerifier {}
 

--- a/test/SimplePDPService.t.sol
+++ b/test/SimplePDPService.t.sol
@@ -36,7 +36,7 @@ contract SimplePDPServiceTest is Test {
     function testOnlyPDPVerifierCanAddRecord() public {
         vm.prank(address(0xdead));
         vm.expectRevert("Caller is not the PDP verifier");
-        pdpService.proofSetCreated(proofSetId, address(this), empty);
+        pdpService.proofSetCreated(proofSetId, address(this), address(0x01), empty);
     }
 
     function testGetMaxProvingPeriod() public view {


### PR DESCRIPTION
Doing this in the Verifier contract allows ALL listeners to access the beneficiary address which they can then use for payments.