### PR TITLE
Add `pieceCids` to `PiecesAdded` event

### DIFF
--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -61,7 +61,7 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     event DataSetDeleted(uint256 indexed setId, uint256 deletedLeafCount);
     event DataSetEmpty(uint256 indexed setId);
 
-    event PiecesAdded(uint256 indexed setId, uint256[] pieceIds, bytes[] pieceCids);
+    event PiecesAdded(uint256 indexed setId, uint256[] pieceIds, Cids.Cid[] pieceCids);
     event PiecesRemoved(uint256 indexed setId, uint256[] pieceIds);
 
     event ProofFeePaid(uint256 indexed setId, uint256 fee, uint64 price, int32 expo);
@@ -445,12 +445,12 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         require(storageProvider[setId] == msg.sender, "Only the storage provider can add pieces");
         uint256 firstAdded = nextPieceId[setId];
         uint256[] memory pieceIds = new uint256[](pieceData.length);
-        bytes[] memory pieceCidsAdded = new bytes[](pieceData.length);
+        Cids.Cid[] memory pieceCidsAdded = new Cids.Cid[](pieceData.length);
 
         for (uint256 i = 0; i < nPieces; i++) {
             addOnePiece(setId, i, pieceData[i]);
             pieceIds[i] = firstAdded + i;
-            pieceCidsAdded[i] = pieceData[i].data;
+            pieceCidsAdded[i] = pieceData[i];
         }
         emit PiecesAdded(setId, pieceIds, pieceCidsAdded);
 

--- a/src/interfaces/IPDPEvents.sol
+++ b/src/interfaces/IPDPEvents.sol
@@ -12,7 +12,7 @@ interface IPDPEvents {
     );
     event DataSetDeleted(uint256 indexed setId, uint256 deletedLeafCount);
     event DataSetEmpty(uint256 indexed setId);
-    event PiecesAdded(uint256 indexed setId, uint256[] pieceIds, bytes[] pieceCids);
+    event PiecesAdded(uint256 indexed setId, uint256[] pieceIds, Cids.Cid[] pieceCids);
     event PiecesRemoved(uint256 indexed setId, uint256[] pieceIds);
     event ProofFeePaid(uint256 indexed setId, uint256 fee, uint64 price, int32 expo);
     event PossessionProven(uint256 indexed setId, IPDPTypes.PieceIdAndOffset[] challenges);

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -279,7 +279,7 @@ contract PDPVerifierDataSetMutateTest is Test, PieceHelper {
         pieces[0] = makeSamplePiece(leafCount);
 
         vm.expectEmit(true, true, false, false);
-        emit IPDPEvents.PiecesAdded(setId, new uint256[](0), new bytes[](0));
+        emit IPDPEvents.PiecesAdded(setId, new uint256[](0), new Cids.Cid[](0));
         uint256 pieceId = pdpVerifier.addPieces(setId, pieces, empty);
         assertEq(pdpVerifier.getChallengeRange(setId), 0);
 
@@ -311,9 +311,9 @@ contract PDPVerifierDataSetMutateTest is Test, PieceHelper {
         uint256[] memory pieceIds = new uint256[](2);
         pieceIds[0] = 0;
         pieceIds[1] = 1;
-        bytes[] memory pieceCids = new bytes[](2);
-        pieceCids[0] = pieces[0].data;
-        pieceCids[1] = pieces[1].data;
+        Cids.Cid[] memory pieceCids = new Cids.Cid[](2);
+        pieceCids[0] = pieces[0];
+        pieceCids[1] = pieces[1];
         emit IPDPEvents.PiecesAdded(setId, pieceIds, pieceCids);
         uint256 firstId = pdpVerifier.addPieces(setId, pieces, empty);
         assertEq(firstId, 0);


### PR DESCRIPTION
This allows indexers to map roots via their cids, not just their ids. This is required for FilCDN, as root cids will be part of the asset URL.

The migration test is failing. I have no idea why. Could it be because I'm using the `Cids.Cid` type in the event interface?