### PR TITLE
Feature/add abi to release

### DIFF
--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -8,15 +8,25 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-      - name: Install Foundry & deps
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+        
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Install Dependencies
         run: |
-          ./configure
-          curl -L https://foundry.paradigm.xyz | bash
-          foundryup
           forge install
           npm ci
 

--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -1,0 +1,32 @@
+name: Publish ABIs
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry & deps
+        run: |
+          ./configure
+          curl -L https://foundry.paradigm.xyz | bash
+          foundryup
+          forge install
+          npm ci
+
+      - name: Build & extract ABIs
+        run: |
+          make build
+          make extract-abis
+
+      - name: Upload ABI assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: abi/*.abi.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -3,6 +3,7 @@ name: Publish ABIs
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ out/
 # Configuration backups
 configure.backup
 node_modules/
+abi/

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,12 @@ deploy-devnet:
 .PHONY: deploy-mainnet
 deploy-mainnet:
 	./tools/deploy-mainnet.sh
+
+# Extract just the ABI arrays into abi/ContractName.abi.json
+.PHONY: extract-abis
+extract-abis:
+	mkdir -p abi
+	@find out -type f -name '*.json' | while read file; do \
+	  name=$$(basename "$${file%.*}"); \
+	  jq '.abi' "$${file}" > "abi/$${name}.abi.json"; \
+	done


### PR DESCRIPTION
 This pull request implements issue [#168](https://github.com/FilOzone/pdp/issues/168) by: 

* **Makefile**  
  * Adds a new `extract-abis` target that:
    * Scans `out/**/*.json` artifacts  
    * Extracts the `"abi"` field from each  
    * Writes standalone files to `abi/<ContractName>.abi.json`  

* **GitHub Actions**  
  * Introduces `.github/workflows/publish-abis.yml`  
  * Triggers on:
    * `release.created` → attaches all `abi/*.abi.json` to the Release assets  
    * `workflow_dispatch` → allows manual testing from the Actions tab  
  * Installs Foundry, `jq`, Node.js  
  * Runs `make build && make extract-abis`  
  * Uses `softprops/action-gh-release` to upload the ABIs  

* **Documentation**  
  * _Optional:_ Update `README.md` to note that contract ABIs are now available under each Release’s **Assets** as `<ContractName>.abi.json`.  

I'm happy to make any adjustments if needed.
