### PR TITLE
[DO NOT MERGE] Add GitHub workflow to auto-add issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -1,0 +1,19 @@
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add all issues and prs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}


### PR DESCRIPTION
## Summary
- Adds a GitHub workflow that automatically adds newly opened issues and pull requests to the FilOzone project board
- This is a test implementation for https://github.com/FilOzone/github-mgmt/issues/10
- Uses the `actions/add-to-project@v1.0.2` action with the `FILOZZY_CI_ADD_TO_PROJECT` secret

## Test plan
- [ ] Verify the workflow file is properly formatted
- [ ] Test by creating a new issue after this PR is merged
- [ ] Test by creating a new PR after this PR is merged
- [ ] Confirm items are automatically added to the project board
- [ ] Once confirmed working, distribute to other FilOzone repositories

🤖 Generated with [Claude Code](https://claude.ai/code)