### PR TITLE
IPDPProvingSchedule: add service method

### DIFF
--- a/src/IPDPProvingSchedule.sol
+++ b/src/IPDPProvingSchedule.sol
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
+import {PDPListener} from "./PDPVerifier.sol";
+
 /// @title IPDPProvingWindow
 /// @notice Interface for PDP Service SLA specifications
 interface IPDPProvingSchedule {
+    /// @notice Returns the service associated with this proving schedule
+    /// @return The PDP Service
+    function service() external view returns (PDPListener);
+
     /// @notice Returns the number of epochs allowed before challenges must be resampled
     /// @return Maximum proving period in epochs
     function getMaxProvingPeriod() external view returns (uint64);


### PR DESCRIPTION

Reviewer @rvagg
The FilecoinWarmStorageServiceStateView contract has `service` already.
Adding `service` to the interface should help with https://github.com/FilOzone/filecoin-services/issues/163
#### Test plan
TODO check that the filecoin-services build succeeds with this change
#### Changes
* add `service`