### PR TITLE
feat!: switch to a more compact form of IPDPProvingSchedule

### DIFF
--- a/src/IPDPProvingSchedule.sol
+++ b/src/IPDPProvingSchedule.sol
@@ -1,27 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.20;
 
-/// @title IPDPProvingWindow
+/// @title IPDPProvingSchedule
 /// @notice Interface for PDP Service SLA specifications
 interface IPDPProvingSchedule {
-    /// @notice Returns the number of epochs allowed before challenges must be resampled
-    /// @return Maximum proving period in epochs
-    function getMaxProvingPeriod() external view returns (uint64);
+    /**
+     * @notice Returns PDP configuration values
+     * @return maxProvingPeriod Maximum number of epochs between proofs
+     * @return challengeWindow Number of epochs for the challenge window
+     * @return challengesPerProof Number of challenges required per proof
+     * @return initChallengeWindowStart Initial challenge window start for new data sets assuming proving period starts now
+     */
+    function getPDPConfig()
+        external
+        view
+        returns (
+            uint64 maxProvingPeriod,
+            uint256 challengeWindow,
+            uint256 challengesPerProof,
+            uint256 initChallengeWindowStart
+        );
 
-    /// @notice Returns the number of epochs at the end of a proving period during which proofs can be submitted
-    /// @return Challenge window size in epochs
-    function challengeWindow() external view returns (uint256);
-
-    /// @notice Value for initializing the challenge window start for any data set assuming proving period starts now
-    // @return Initial challenge window start in epochs
-    function initChallengeWindowStart() external view returns (uint256);
-
-    /// @notice Calculates the start of the next challenge window for a given data set
-    /// @param setId The ID of the data set
-    /// @return The block number when the next challenge window starts
-    function nextChallengeWindowStart(uint256 setId) external view returns (uint256);
-
-    /// @notice Returns the required number of challenges/merkle inclusion proofs per data set
-    /// @return Number of challenges required per proof
-    function getChallengesPerProof() external pure returns (uint64);
+    /**
+     * @notice Returns the start of the next challenge window for a data set
+     * @param setId The ID of the data set
+     * @return The block number when the next challenge window starts
+     */
+    function nextPDPChallengeWindowStart(uint256 setId) external view returns (uint256);
 }


### PR DESCRIPTION
Ref: https://github.com/FilOzone/filecoin-services/issues/163
Ref: https://github.com/FilOzone/filecoin-services/pull/167

Aiming to reduce service contract size, but also wanting it to implement the necessary interface to be a listener for PDP, this bundles up all the configuration numbers into a single `getPDPConfig`, with the big dynamic one as `nextPDPChallengeWindowStart`. They now have the name in them too with the assumption that implementers of this may have other verifiers or interfaces to deal with so we can avoid conflicts.

Note though, `getPDPConfig` does have one slightly dynamic return, `initChallengeWindowStart` changes with `block.number` so each call to this will change per epoch.