### PR TITLE
Pyth: accept old prices without emit log

### DIFF
--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -577,7 +577,7 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         }
     }
 
-    function calculateProofFee(uint256 setId, uint256 estimatedGasFee) public returns (uint256) {
+    function calculateProofFee(uint256 setId, uint256 estimatedGasFee) public view returns (uint256) {
         uint256 rawSize = 32 * challengeRange[setId];
         (uint64 filUsdPrice, int32 filUsdPriceExpo) = getFILUSDPrice();
 
@@ -819,22 +819,10 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         return BitOps.ctz(index + 1);
     }
 
-    event PriceOracleFailure(bytes reason);
-
     // Add function to get FIL/USD price
-    function getFILUSDPrice() public returns (uint64, int32) {
-        // Get FIL/USD price no older than 1 day
-        try PYTH.getPriceNoOlderThan(FIL_USD_PRICE_FEED_ID, SECONDS_IN_DAY) returns (PythStructs.Price memory priceData)
-        {
-            require(priceData.price > 0, "failed to validate: price must be greater than 0");
-            // Return the price and exponent representing USD per FIL
-            return (uint64(priceData.price), priceData.expo);
-        } catch (bytes memory reason) {
-            // Log issue and fallback on latest unsafe price data
-            emit PriceOracleFailure(reason);
-            PythStructs.Price memory priceData = PYTH.getPriceUnsafe(FIL_USD_PRICE_FEED_ID);
-            require(priceData.price > 0, "failed to validate: price must be greater than 0");
-            return (uint64(priceData.price), priceData.expo);
-        }
+    function getFILUSDPrice() public view returns (uint64, int32) {
+        PythStructs.Price memory priceData = PYTH.getPriceUnsafe(FIL_USD_PRICE_FEED_ID);
+        require(priceData.price > 0, "failed to validate: price must be greater than 0");
+        return (uint64(priceData.price), priceData.expo);
     }
 }

--- a/src/interfaces/IPDPEvents.sol
+++ b/src/interfaces/IPDPEvents.sol
@@ -17,6 +17,5 @@ interface IPDPEvents {
     event ProofFeePaid(uint256 indexed setId, uint256 fee, uint64 price, int32 expo);
     event PossessionProven(uint256 indexed setId, IPDPTypes.PieceIdAndOffset[] challenges);
     event NextProvingPeriod(uint256 indexed setId, uint256 challengeEpoch, uint256 leafCount);
-    event PriceOracleFailure(bytes errorData);
     event ContractUpgraded(string version, address newImplementation);
 }

--- a/test/PDPVerifierProofTest.t.sol
+++ b/test/PDPVerifierProofTest.t.sol
@@ -34,7 +34,7 @@ contract PDPVerifierProofTest is Test, ProofBuilderHelper, PieceHelper {
 
     function createPythCallData() internal view returns (bytes memory, PythStructs.Price memory) {
         bytes memory pythCallData =
-            abi.encodeWithSelector(IPyth.getPriceNoOlderThan.selector, pdpVerifier.FIL_USD_PRICE_FEED_ID(), 86400);
+            abi.encodeWithSelector(IPyth.getPriceUnsafe.selector, pdpVerifier.FIL_USD_PRICE_FEED_ID());
 
         PythStructs.Price memory price = PythStructs.Price({price: 5, conf: 0, expo: 0, publishTime: 0});
 


### PR DESCRIPTION
Reviewer @zenground0

Curio is expecting `calculateProofFee` to be `view`.
What is preventing that is that we are logging that the timestamp is out of date before just using the data anyway.
That isn't a great way to handle the situation.
The prior behavior is equivalent to `getPriceUnsafe` but with an extra staticcall in the outdated case.

If we want to notice that the price is outdated we can monitor the oracle directly; this is no more difficult than watching for `PriceOracleFailure` logs.
On-chain logs shouldn't be used like `logger` logs.
A better way to think of them is like a SQL database row.


It's also probably not a great experience for the price to change and then your transaction reverts, but that's a separate issue.
#### Changes
* use `getPriceUnsafe`, remove log
* make `calculateProofFee` a `view` method
* fix tests