### PR TITLE
chore: update optimizer_runs to reduce contract size

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,6 +15,6 @@ remappings = [
     '@pythnetwork/pyth-sdk-solidity/=lib/pyth-sdk-solidity/',
 ]
 
-optimizer_runs = 200
+optimizer_runs = 1
 via_ir = true
 


### PR DESCRIPTION
With the current settings, the PDP contract is above the size limit:

```
forge build --sizes
╭------------------------------------+------------------+-------------------+--------------------+---------------------╮
| Contract                           | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
+======================================================================================================================+
| Address                            | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| BadListener                        | 2,518            | 2,545             | 22,058             | 46,607              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| BitOps                             | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Cids                               | 235              | 265               | 24,341             | 48,887              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1967Proxy                       | 141              | 723               | 24,435             | 48,429              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1967Utils                       | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Errors                             | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ExtraDataListener                  | 3,299            | 3,326             | 21,277             | 45,826              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Hashes                             | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Math                               | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MerkleProve                        | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MerkleVerify                       | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MockStorageProviderChangedListener | 2,525            | 2,552             | 22,051             | 46,600              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MyERC1967Proxy                     | 141              | 701               | 24,435             | 48,451              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PDPFees                            | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PDPRecordKeeper                    | 1,681            | 1,708             | 22,895             | 47,444              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PDPVerifier                        | 24,946           | 25,160            | -370               | 23,992              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Panic                              | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ProofUtil                          | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PythStructs                        | 57               | 81                | 24,519             | 49,071              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SafeCast                           | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SignedMath                         | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SimplePDPService                   | 7,641            | 7,850             | 16,935             | 41,302              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| StorageSlot                        | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Strings                            | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SumTreeInternalTestPDPVerifier     | 25,086           | 25,300            | -510               | 23,852              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| TestingRecordKeeperService         | 8,095            | 8,122             | 16,481             | 41,030              |
╰------------------------------------+------------------+-------------------+--------------------+---------------------╯

Error: some contracts exceed the runtime size limit (EIP-170: 24576 bytes)
```

Reducing the `optimizer_runs` to 200 makes it pass:

```
╭------------------------------------+------------------+-------------------+--------------------+---------------------╮
| Contract                           | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
+======================================================================================================================+
| Address                            | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| BadListener                        | 1,729            | 1,756             | 22,847             | 47,396              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| BitOps                             | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Cids                               | 150              | 179               | 24,426             | 48,973              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1967Proxy                       | 130              | 712               | 24,446             | 48,440              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ERC1967Utils                       | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Errors                             | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ExtraDataListener                  | 2,411            | 2,438             | 22,165             | 46,714              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Hashes                             | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Math                               | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MerkleProve                        | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MerkleVerify                       | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MockStorageProviderChangedListener | 1,761            | 1,788             | 22,815             | 47,364              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| MyERC1967Proxy                     | 130              | 690               | 24,446             | 48,462              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PDPFees                            | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PDPRecordKeeper                    | 1,319            | 1,346             | 23,257             | 47,806              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PDPVerifier                        | 18,532           | 18,746            | 6,044              | 30,406              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Panic                              | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| ProofUtil                          | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| PythStructs                        | 57               | 81                | 24,519             | 49,071              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SafeCast                           | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SignedMath                         | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SimplePDPService                   | 5,286            | 5,495             | 19,290             | 43,657              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| StorageSlot                        | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| Strings                            | 57               | 85                | 24,519             | 49,067              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| SumTreeInternalTestPDPVerifier     | 18,642           | 18,856            | 5,934              | 30,296              |
|------------------------------------+------------------+-------------------+--------------------+---------------------|
| TestingRecordKeeperService         | 5,524            | 5,551             | 19,052             | 43,601              |
╰------------------------------------+------------------+-------------------+--------------------+---------------------╯
```