### PR TITLE
feat: start data set IDs at 1

### DIFF
--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -153,6 +153,7 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
         challengeFinality = _challengeFinality;
+        nextDataSetId = 1; // Data sets start at 1
     }
 
     string public constant VERSION = "2.0.0";


### PR DESCRIPTION
Avoid problems with default value matching. Matches how we deal with rail IDs and service provider IDs.

Closes: https://github.com/FilOzone/filecoin-services/issues/216

This should be a non-breaking change to a deployed contract, upgrading would essentially be a noop for any contract that has data sets already (also for any that don't because this is set in initialize()). So it's only relevant for new deployments.