### PR TITLE
chore: prep v2.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [2.1.0] - 2025-09-16
+
+### 🚀 Added
+- **PieceCIDv2 Support**: Added comprehensive support for Piece CID version 2 ([#184](https://github.com/FilOzone/pdp/pull/184))
+  - New `Cids.sol` library with CIDv2 handling capabilities
+  - Support for both CIDv1 and CIDv2 formats 
+  - Enhanced piece data validation using CID height information
+  - Golden tests for CommPv2 functionality
+- **Enhanced Data Set Management**: Data set IDs now start at 1 instead of 0 for better user experience ([#196](https://github.com/FilOzone/pdp/pull/196))
+- **CI/CD Improvements**: 
+  - New GitHub Actions workflow for publishing contract ABIs to releases ([#170](https://github.com/FilOzone/pdp/pull/170))
+  - Link checking workflow to validate documentation links
+  - Extract-abis Makefile target for ABI generation
+- **Event Enhancement**: Added `root_cids` to `RootsAdded` event for better piece tracking ([#169](https://github.com/FilOzone/pdp/pull/169))
+
+### 🔧 Changed
+- **BREAKING**: `IPDPProvingSchedule` interface updated to a more compact form with significant changes to method signatures and behavior ([#187](https://github.com/FilOzone/pdp/pull/187), [#190](https://github.com/FilOzone/pdp/pull/190))
+- **Interface Updates**: IPDPProvingSchedule methods changed from `pure` to `view` for accurate state access patterns ([#186](https://github.com/FilOzone/pdp/pull/186))
+- **Price Validation**: Updated price validation logic to accept older price data for improved reliability ([#191](https://github.com/FilOzone/pdp/pull/191))
+- **Performance Optimization**: Reduced optimizer runs to minimize deployed contract size ([#194](https://github.com/FilOzone/pdp/pull/194))
+- **Code Architecture**: Transitioned from `IPDPTypes.PieceData` to `Cids.Cid` throughout the codebase for better type consistency ([#184](https://github.com/FilOzone/pdp/pull/184))
+- **Code Quality**: Comprehensive formatting improvements across all Solidity files and tests ([#185](https://github.com/FilOzone/pdp/pull/185))
+- **Documentation**: Updated README to point to latest release ([#192](https://github.com/FilOzone/pdp/pull/192))
+
+### 🐛 Fixed
+- Various test stability improvements and bug fixes
+- Enhanced error handling in CID processing
+- Improved code formatting consistency
+
+### 📝 Changelog
+
+For the set of changes since the last tag:
+
+**[View all changes between v2.0.0 and v2.1.0](https://github.com/FilOzone/pdp/compare/v2.0.0...v2.1.0)**
+
 ## [2.0.0] - 2025-07-20
 ### Changed
 - **BREAKING**: Renamed core terminology throughout the codebase for better clarity, for each of the following, all functions, variables, events, and parameters have been changed.
@@ -117,7 +152,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Performance
 - Performance-related improvements
 
-[Unreleased]: https://github.com/filozone/pdp/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/filozone/pdp/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/filozone/pdp/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/filozone/pdp/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/filozone/pdp/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/filozone/pdp/releases/tag/v1.0.0


### PR DESCRIPTION
I've prepared the v2.1.0 changelog in this PR. We have two options moving forward:
- If [PR #195](https://github.com/FilOzone/pdp/pull/195) gets reviewed/lands soon, we can use it to test the release automation triggered by a version bump.
- Otherwise, we can proceed with a manual release this time to unblock things and get the PDP update out to Calibnet and Mainnet.
 