### PR TITLE
fix: remove npm ci from publish-abis workflow

### DIFF
--- a/.github/workflows/publish-abis.yml
+++ b/.github/workflows/publish-abis.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install Dependencies
         run: |
           forge install
-          npm ci
 
       - name: Build & extract ABIs
         run: |


### PR DESCRIPTION
The `publish-abis.yml` workflow was failing after the publishing of v2.1.0 here: https://github.com/FilOzone/pdp/actions/runs/17792160390 because it tried to run `npm ci`, but PDP doesn't have a `package.json` file at the root level iiuc.

I removed the unnecessary `npm ci` step. The workflow now only runs `forge install` which is all that's needed for Foundry dependency management.