### PR TITLE
fix: vm.getBlockNumber

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ script = 'script'
 out = 'out'
 libs = ['lib']
 cache_path = 'cache'
-solc = "0.8.23"
+solc = "0.8.30"
 
 # For dependencies
 remappings = [


### PR DESCRIPTION

Reviewer @zenground0
Fixes https://github.com/FilOzone/pdp/issues/205
#### Changes
* up solidity to 0.8.30 which breaks the tests
* use vm.getBlockNumber in the tests which fixes them again