### PR TITLE
feat: use precompile for native payments and burn

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/pyth-sdk-solidity"]
 	path = lib/pyth-sdk-solidity
 	url = https://github.com/pyth-network/pyth-sdk-solidity
+[submodule "lib/fvm-solidity"]
+	path = lib/fvm-solidity
+	url = https://github.com/filecoin-project/fvm-solidity

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ script = 'script'
 out = 'out'
 libs = ['lib']
 cache_path = 'cache'
-solc = "0.8.23"
+solc = "0.8.30"
 
 # For dependencies
 remappings = [

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 pragma solidity ^0.8.13;
 
-import {UUPSUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {MockFVMTest} from "fvm-solidity/mocks/MockFVMTest.sol";
 import {Test} from "forge-std/Test.sol";
+import {UUPSUpgradeable} from "../lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {Cids} from "../src/Cids.sol";
 import {PDPVerifier, PDPListener} from "../src/PDPVerifier.sol";
 import {MyERC1967Proxy} from "../src/ERC1967Proxy.sol";
@@ -16,12 +17,13 @@ import {ProofBuilderHelper} from "./ProofBuilderHelper.t.sol";
 import {PythStructs} from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 import {IPyth} from "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 
-contract PDPVerifierDataSetCreateDeleteTest is Test {
+contract PDPVerifierDataSetCreateDeleteTest is MockFVMTest {
     TestingRecordKeeperService listener;
     PDPVerifier pdpVerifier;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         uint256 challengeFinality = 2;
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, challengeFinality);
@@ -181,7 +183,7 @@ contract PDPVerifierDataSetCreateDeleteTest is Test {
     }
 }
 
-contract PDPVerifierStorageProviderTest is Test, PieceHelper {
+contract PDPVerifierStorageProviderTest is MockFVMTest, PieceHelper {
     PDPVerifier pdpVerifier;
     TestingRecordKeeperService listener;
     address public storageProvider;
@@ -189,7 +191,8 @@ contract PDPVerifierStorageProviderTest is Test, PieceHelper {
     address public nonStorageProvider;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, 2);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -273,14 +276,15 @@ contract PDPVerifierStorageProviderTest is Test, PieceHelper {
     }
 }
 
-contract PDPVerifierDataSetMutateTest is Test, PieceHelper {
+contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
     uint256 constant CHALLENGE_FINALITY_DELAY = 2;
 
     PDPVerifier pdpVerifier;
     TestingRecordKeeperService listener;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, CHALLENGE_FINALITY_DELAY);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -686,12 +690,13 @@ contract PDPVerifierDataSetMutateTest is Test, PieceHelper {
     }
 }
 
-contract PDPVerifierPaginationTest is Test, PieceHelper {
+contract PDPVerifierPaginationTest is MockFVMTest, PieceHelper {
     PDPVerifier pdpVerifier;
     TestingRecordKeeperService listener;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         uint256 challengeFinality = 2;
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, challengeFinality);
@@ -967,10 +972,11 @@ contract SumTreeInternalTestPDPVerifier is PDPVerifier {
     }
 }
 
-contract SumTreeHeightTest is Test {
+contract SumTreeHeightTest is MockFVMTest {
     SumTreeInternalTestPDPVerifier pdpVerifier;
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new SumTreeInternalTestPDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, 2);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -1096,14 +1102,15 @@ contract SumTreeHeightTest is Test {
     }
 }
 
-contract SumTreeAddTest is Test, PieceHelper {
+contract SumTreeAddTest is MockFVMTest, PieceHelper {
     SumTreeInternalTestPDPVerifier pdpVerifier;
     TestingRecordKeeperService listener;
     uint256 testSetId;
     uint256 constant CHALLENGE_FINALITY_DELAY = 100;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new SumTreeInternalTestPDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, CHALLENGE_FINALITY_DELAY);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -1390,13 +1397,14 @@ contract BadListener is PDPListener {
     }
 }
 
-contract PDPListenerIntegrationTest is Test, PieceHelper {
+contract PDPListenerIntegrationTest is MockFVMTest, PieceHelper {
     PDPVerifier pdpVerifier;
     BadListener badListener;
     uint256 constant CHALLENGE_FINALITY_DELAY = 2;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, CHALLENGE_FINALITY_DELAY);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -1475,13 +1483,14 @@ contract ExtraDataListener is PDPListener {
     }
 }
 
-contract PDPVerifierExtraDataTest is Test, PieceHelper {
+contract PDPVerifierExtraDataTest is MockFVMTest, PieceHelper {
     PDPVerifier pdpVerifier;
     ExtraDataListener extraDataListener;
     uint256 constant CHALLENGE_FINALITY_DELAY = 2;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, CHALLENGE_FINALITY_DELAY);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -1528,13 +1537,14 @@ contract PDPVerifierExtraDataTest is Test, PieceHelper {
     }
 }
 
-contract PDPVerifierE2ETest is Test, ProofBuilderHelper, PieceHelper {
+contract PDPVerifierE2ETest is MockFVMTest, ProofBuilderHelper, PieceHelper {
     PDPVerifier pdpVerifier;
     TestingRecordKeeperService listener;
     uint256 constant CHALLENGE_FINALITY_DELAY = 2;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, CHALLENGE_FINALITY_DELAY);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);
@@ -1754,7 +1764,7 @@ contract MockStorageProviderChangedListener is PDPListener {
     function nextProvingPeriod(uint256, uint256, uint256, bytes calldata) external override {}
 }
 
-contract PDPVerifierStorageProviderListenerTest is Test {
+contract PDPVerifierStorageProviderListenerTest is MockFVMTest {
     PDPVerifier pdpVerifier;
     MockStorageProviderChangedListener listener;
     address public storageProvider;
@@ -1762,7 +1772,8 @@ contract PDPVerifierStorageProviderListenerTest is Test {
     address public nonStorageProvider;
     bytes empty = new bytes(0);
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, 2);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -307,11 +307,11 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
 
         // flush add
         vm.expectEmit(true, true, false, false);
-        emit IPDPEvents.NextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, 2);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        emit IPDPEvents.NextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, 2);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         assertEq(pdpVerifier.getDataSetLeafCount(setId), leafCount);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), block.number + CHALLENGE_FINALITY_DELAY);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY);
         assertEq(pdpVerifier.getChallengeRange(setId), leafCount);
 
         assertTrue(pdpVerifier.pieceLive(setId, pieceId));
@@ -341,12 +341,12 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         assertEq(firstId, 0);
         // flush add
         vm.expectEmit(true, true, true, false);
-        emit IPDPEvents.NextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, 6);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        emit IPDPEvents.NextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, 6);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         uint256 expectedLeafCount = 64 + 128;
         assertEq(pdpVerifier.getDataSetLeafCount(setId), expectedLeafCount);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), block.number + CHALLENGE_FINALITY_DELAY);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY);
 
         assertTrue(pdpVerifier.pieceLive(setId, firstId));
         assertTrue(pdpVerifier.pieceLive(setId, firstId + 1));
@@ -412,8 +412,8 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         pieces[0] = makeSamplePiece(2);
         pdpVerifier.addPieces(setId, pieces, empty);
         assertEq(pdpVerifier.getNextChallengeEpoch(setId), pdpVerifier.NO_CHALLENGE_SCHEDULED()); // Not updated on first add anymore
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), block.number + CHALLENGE_FINALITY_DELAY);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY);
 
         // Remove piece
         uint256[] memory toRemove = new uint256[](1);
@@ -422,7 +422,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
 
         vm.expectEmit(true, true, false, false);
         emit IPDPEvents.PiecesRemoved(setId, toRemove);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty); // flush
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty); // flush
 
         assertEq(pdpVerifier.getNextChallengeEpoch(setId), pdpVerifier.NO_CHALLENGE_SCHEDULED());
         assertEq(pdpVerifier.pieceLive(setId, 0), false);
@@ -466,7 +466,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
 
         vm.expectEmit(true, true, false, false);
         emit IPDPEvents.PiecesRemoved(setId, toRemove);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty); // flush
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty); // flush
 
         assertEq(pdpVerifier.pieceLive(setId, 0), false);
         assertEq(pdpVerifier.pieceLive(setId, 1), true);
@@ -474,7 +474,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
 
         assertEq(pdpVerifier.getNextPieceId(setId), 3);
         assertEq(pdpVerifier.getDataSetLeafCount(setId), 64 / 32);
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), block.number + CHALLENGE_FINALITY_DELAY);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY);
 
         bytes memory emptyCidData = new bytes(0);
         assertEq(pdpVerifier.getPieceCid(setId, 0).data, emptyCidData);
@@ -501,7 +501,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         vm.expectRevert("Can only schedule removal of existing pieces");
         pdpVerifier.schedulePieceDeletions(setId, toRemove, empty);
         // Actual removal does not fail
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         // Scheduling both unchallengeable and challengeable pieces for removal succeeds
         // scheduling duplicate ids in both cases succeeds
@@ -518,7 +518,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         assertEq(true, pdpVerifier.pieceChallengable(setId, 0));
         assertEq(false, pdpVerifier.pieceChallengable(setId, 1));
         pdpVerifier.schedulePieceDeletions(setId, toRemove2, empty);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         assertEq(false, pdpVerifier.pieceLive(setId, 0));
         assertEq(false, pdpVerifier.pieceLive(setId, 1));
@@ -555,7 +555,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
 
         // Test nextProvingPeriod with too large extra data
         vm.expectRevert("Extra data too large");
-        pdpVerifier.nextProvingPeriod(setId, block.number + 10, tooLargeExtraData);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + 10, tooLargeExtraData);
 
         // Test deleteDataSet with too large extra data
         vm.expectRevert("Extra data too large");
@@ -599,7 +599,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         // Try to call nextProvingPeriod as non-storage-provider
         vm.prank(nonStorageProvider);
         vm.expectRevert("only the storage provider can move to next proving period");
-        pdpVerifier.nextProvingPeriod(setId, block.number + 10, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + 10, empty);
     }
 
     function testNextProvingPeriodChallengeEpochTooSoon() public {
@@ -610,7 +610,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         pdpVerifier.addPieces(setId, pieces, empty);
 
         // Current block number
-        uint256 currentBlock = block.number;
+        uint256 currentBlock = vm.getBlockNumber();
 
         // Try to call nextProvingPeriod with a challenge epoch that is not at least
         // challengeFinality epochs in the future
@@ -644,10 +644,10 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
 
         // Try to set next proving period with various values
         vm.expectRevert("can only start proving once leaves are added");
-        pdpVerifier.nextProvingPeriod(setId, block.number + 100, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + 100, empty);
 
         vm.expectRevert("can only start proving once leaves are added");
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         vm.expectRevert("can only start proving once leaves are added");
         pdpVerifier.nextProvingPeriod(setId, type(uint256).max, empty);
@@ -660,7 +660,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         // Try to call nextProvingPeriod on the empty data set
         // Should revert because no leaves have been added yet
         vm.expectRevert("can only start proving once leaves are added");
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
     }
 
     function testEmitDataSetEmptyEvent() public {
@@ -681,7 +681,7 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         emit IPDPEvents.DataSetEmpty(setId);
 
         // Call nextProvingPeriod which should remove the piece and emit the event
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         // Verify the data set is indeed empty
         assertEq(pdpVerifier.getDataSetLeafCount(setId), 0);
@@ -781,7 +781,7 @@ contract PDPVerifierPaginationTest is MockFVMTest, PieceHelper {
 
         // Move to next proving period to make removals effective
         uint256 challengeFinality = pdpVerifier.getChallengeFinality();
-        pdpVerifier.nextProvingPeriod(setId, block.number + challengeFinality, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + challengeFinality, empty);
 
         // Should return only 7 active pieces
         (Cids.Cid[] memory pieces, uint256[] memory ids, uint256[] memory sizes, bool hasMore) =
@@ -1184,7 +1184,7 @@ contract SumTreeAddTest is MockFVMTest, PieceHelper {
         // Remove pieces in batch
         pdpVerifier.schedulePieceDeletions(testSetId, pieceIdsToRemove, empty);
         // flush adds and removals
-        pdpVerifier.nextProvingPeriod(testSetId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(testSetId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
         for (uint256 i = 0; i < pieceIdsToRemove.length; i++) {
             bytes memory zeroBytes;
             assertEq(pdpVerifier.getPieceCid(testSetId, pieceIdsToRemove[i]).data, zeroBytes);
@@ -1328,7 +1328,7 @@ contract SumTreeAddTest is MockFVMTest, PieceHelper {
             pdpVerifier.addPieces(testSetId, pieceDataArray, empty);
         }
         pdpVerifier.schedulePieceDeletions(testSetId, pieceIdsToRemove, empty);
-        pdpVerifier.nextProvingPeriod(testSetId, block.number + CHALLENGE_FINALITY_DELAY, empty); //flush removals
+        pdpVerifier.nextProvingPeriod(testSetId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty); //flush removals
 
         assertFindPieceAndOffset(testSetId, 0, 3, 0);
         assertFindPieceAndOffset(testSetId, 1, 4, 0);
@@ -1440,10 +1440,10 @@ contract PDPListenerIntegrationTest is MockFVMTest, PieceHelper {
 
         badListener.setBadOperation(PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD);
         vm.expectRevert("Failing operation");
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         badListener.setBadOperation(PDPRecordKeeper.OperationType.NONE);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
     }
 }
 
@@ -1528,7 +1528,7 @@ contract PDPVerifierExtraDataTest is MockFVMTest, PieceHelper {
         );
 
         // Test NEXT_PROVING_PERIOD operation
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
         assertEq(
             extraDataListener.getExtraData(setId, PDPRecordKeeper.OperationType.NEXT_PROVING_PERIOD),
             empty,
@@ -1606,7 +1606,7 @@ contract PDPVerifierE2ETest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         piecesProofPeriod1[1] = makePiece(treesA[1], leafCountsA[1]);
         pdpVerifier.addPieces(setId, piecesProofPeriod1, empty);
         // flush the original addPieces call
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         uint256 challengeRangeProofPeriod1 = pdpVerifier.getChallengeRange(setId);
         assertEq(
@@ -1672,7 +1672,7 @@ contract PDPVerifierE2ETest is MockFVMTest, ProofBuilderHelper, PieceHelper {
 
         pdpVerifier.provePossession{value: 1e18}(setId, proofsProofPeriod1);
 
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
         // CHECK: leaf counts
         assertEq(
             pdpVerifier.getPieceLeafCount(setId, 0),
@@ -1703,7 +1703,7 @@ contract PDPVerifierE2ETest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         // CHECK: the next challenge epoch has been updated
         assertEq(
             pdpVerifier.getNextChallengeEpoch(setId),
-            block.number + CHALLENGE_FINALITY_DELAY,
+            vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY,
             "Next challenge epoch should be updated"
         );
     }

--- a/test/PDPVerifierProofTest.t.sol
+++ b/test/PDPVerifierProofTest.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {IPyth} from "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import {PythStructs} from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+import {MockFVMTest} from "fvm-solidity/mocks/MockFVMTest.sol";
 import {Test} from "forge-std/Test.sol";
 import {Cids} from "../src/Cids.sol";
 import {PDPVerifier, PDPListener} from "../src/PDPVerifier.sol";
@@ -14,13 +15,14 @@ import {IPDPEvents} from "../src/interfaces/IPDPEvents.sol";
 import {PieceHelper} from "./PieceHelper.t.sol";
 import {ProofBuilderHelper} from "./ProofBuilderHelper.t.sol";
 
-contract PDPVerifierProofTest is Test, ProofBuilderHelper, PieceHelper {
+contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
     uint256 constant CHALLENGE_FINALITY_DELAY = 2;
     bytes empty = new bytes(0);
     PDPVerifier pdpVerifier;
     PDPListener listener;
 
-    function setUp() public {
+    function setUp() public override {
+        super.setUp();
         PDPVerifier pdpVerifierImpl = new PDPVerifier();
         bytes memory initializeData = abi.encodeWithSelector(PDPVerifier.initialize.selector, CHALLENGE_FINALITY_DELAY);
         MyERC1967Proxy proxy = new MyERC1967Proxy(address(pdpVerifierImpl), initializeData);

--- a/test/PDPVerifierProofTest.t.sol
+++ b/test/PDPVerifierProofTest.t.sol
@@ -71,9 +71,9 @@ contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         assertEq(pdpVerifier.getNextChallengeEpoch(setId), challengeEpoch);
 
         // Verify the next challenge is in a subsequent epoch after nextProvingPeriod
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
-        assertEq(pdpVerifier.getNextChallengeEpoch(setId), block.number + CHALLENGE_FINALITY_DELAY);
+        assertEq(pdpVerifier.getNextChallengeEpoch(setId), vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY);
     }
 
     receive() external payable {}
@@ -275,7 +275,7 @@ contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         vm.mockCall(address(pdpVerifier.PYTH()), pythCallData, abi.encode(price));
 
         pdpVerifier.provePossession{value: 1e18}(setId, proofs);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty); // resample
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty); // resample
 
         uint256 nextChallengeEpoch = pdpVerifier.getNextChallengeEpoch(setId);
         assertNotEq(nextChallengeEpoch, challengeEpoch);
@@ -322,7 +322,7 @@ contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         removePieces[0] = newPieceId;
         pdpVerifier.schedulePieceDeletions(setId, removePieces, empty);
         // flush removes
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty);
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty);
 
         // Make a new proof that is valid with two pieces
         challengeEpoch = pdpVerifier.getNextChallengeEpoch(setId);
@@ -376,14 +376,14 @@ contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         (uint256 setId, bytes32[][] memory tree) = makeDataSetWithOnePiece(leafCount);
 
         // Set challenge sampling far in the future
-        uint256 farFutureBlock = block.number + 1000;
+        uint256 farFutureBlock = vm.getBlockNumber() + 1000;
         pdpVerifier.nextProvingPeriod(setId, farFutureBlock, empty);
         assertEq(
             pdpVerifier.getNextChallengeEpoch(setId), farFutureBlock, "Challenge epoch should be set to far future"
         );
 
         // Reset to a closer block
-        uint256 nearerBlock = block.number + CHALLENGE_FINALITY_DELAY;
+        uint256 nearerBlock = vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY;
         pdpVerifier.nextProvingPeriod(setId, nearerBlock, empty);
         assertEq(
             pdpVerifier.getNextChallengeEpoch(setId), nearerBlock, "Challenge epoch should be reset to nearer block"
@@ -451,7 +451,7 @@ contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         // Create new data set and add pieces.
         uint256 setId = pdpVerifier.createDataSet{value: PDPFees.sybilFee()}(address(listener), empty);
         pdpVerifier.addPieces(setId, pieces, empty);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty); // flush adds
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty); // flush adds
         return (setId, trees);
     }
 
@@ -470,7 +470,7 @@ contract PDPVerifierProofTest is MockFVMTest, ProofBuilderHelper, PieceHelper {
         Cids.Cid[] memory pieces = new Cids.Cid[](1);
         pieces[0] = makePiece(tree, leafCount);
         uint256 pieceId = pdpVerifier.addPieces(setId, pieces, empty);
-        pdpVerifier.nextProvingPeriod(setId, block.number + CHALLENGE_FINALITY_DELAY, empty); // flush adds
+        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + CHALLENGE_FINALITY_DELAY, empty); // flush adds
         return (tree, pieceId);
     }
 


### PR DESCRIPTION

Reviewer @zenground0
https://github.com/filecoin-project/fvm-solidity
I made this library to reuse the precompile code and its mocks across repositories, after demonstrating that the precompile native send method uses less gas.
See also the related filecoin-pay changeset: https://github.com/FilOzone/filecoin-pay/pull/234
#### Changes
* add fvm-solidity dependency for access to precompile
* use FVMPay library for native burn and native payment
* fix tests