### PR TITLE
fix: remove `EXTRA_DATA_MAX_SIZE` limit

### DIFF
--- a/src/PDPVerifier.sol
+++ b/src/PDPVerifier.sol
@@ -43,7 +43,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     // Constants
     uint256 public constant MAX_PIECE_SIZE_LOG2 = 50;
     uint256 public constant MAX_ENQUEUED_REMOVALS = 2000;
-    uint256 public constant EXTRA_DATA_MAX_SIZE = 8192;
     uint256 public constant NO_CHALLENGE_SCHEDULED = 0;
     uint256 public constant NO_PROVEN_EPOCH = 0;
 
@@ -434,7 +433,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     //
     // Only the storage provider (msg.sender) can call this function.
     function createDataSet(address listenerAddr, bytes calldata extraData) public payable returns (uint256) {
-        require(extraData.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
         uint256 sybilFee = _validateAndBurnSybilFee();
 
         uint256 setId = _createDataSet(listenerAddr, extraData);
@@ -445,7 +443,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
     // Removes a data set. Must be called by the storage provider.
     function deleteDataSet(uint256 setId, bytes calldata extraData) public {
-        require(extraData.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
         if (setId >= nextDataSetId) {
             revert("data set id out of bounds");
         }
@@ -494,7 +491,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         if (setId == NEW_DATA_SET_SENTINEL) {
             (bytes memory createPayload, bytes memory addPayload) = abi.decode(extraData, (bytes, bytes));
 
-            require(createPayload.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
             uint256 sybilFee = _validateAndBurnSybilFee();
 
             require(listenerAddr != address(0), "listener required for new dataset");
@@ -524,7 +520,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
         internal
         returns (uint256 firstAdded)
     {
-        require(extraData.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
         uint256 nPieces = pieceData.length;
         require(nPieces > 0, "Must add at least one piece");
 
@@ -569,7 +564,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     // schedulePieceDeletions schedules deletion of a batch of pieces from a data set for the start of the next
     // proving period. It must be called by the storage provider.
     function schedulePieceDeletions(uint256 setId, uint256[] calldata pieceIds, bytes calldata extraData) public {
-        require(extraData.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
         require(dataSetLive(setId), "Data set not live");
         require(storageProvider[setId] == msg.sender, "Only the storage provider can schedule removal of pieces");
         require(
@@ -719,7 +713,6 @@ contract PDPVerifier is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     // Note that this method can be called at any time but the pdpListener will likely consider it
     // a "fault" or other penalizeable behavior to call this method before calling provePossesion.
     function nextProvingPeriod(uint256 setId, uint256 challengeEpoch, bytes calldata extraData) public {
-        require(extraData.length <= EXTRA_DATA_MAX_SIZE, "Extra data too large");
         require(msg.sender == storageProvider[setId], "only the storage provider can move to next proving period");
         require(dataSetLeafCount[setId] > 0, "can only start proving once leaves are added");
 

--- a/test/PDPVerifier.t.sol
+++ b/test/PDPVerifier.t.sol
@@ -639,48 +639,6 @@ contract PDPVerifierDataSetMutateTest is MockFVMTest, PieceHelper {
         assertEq(false, pdpVerifier.pieceLive(setId, 1));
     }
 
-    function testExtraDataMaxSizeLimit() public {
-        // Generate extra data that exceeds the max size (8KB)
-        bytes memory tooLargeExtraData = new bytes(8193); // 8KB + 1 byte
-        for (uint256 i = 0; i < tooLargeExtraData.length; i++) {
-            tooLargeExtraData[i] = 0x41; // ASCII 'A'
-        }
-
-        // First test createDataSet with too large extra data
-        vm.expectRevert("Extra data too large");
-        pdpVerifier.addPieces{value: PDPFees.sybilFee()}(
-            NEW_DATA_SET_SENTINEL, address(listener), new Cids.Cid[](0), abi.encode(tooLargeExtraData, empty)
-        );
-
-        // Now create data set
-        uint256 setId = pdpVerifier.addPieces{value: PDPFees.sybilFee()}(
-            NEW_DATA_SET_SENTINEL, address(listener), new Cids.Cid[](0), abi.encode(empty, empty)
-        );
-        Cids.Cid[] memory pieces = new Cids.Cid[](1);
-
-        // Test addPieces with too large extra data
-        pieces[0] = makeSamplePiece(2);
-        vm.expectRevert("Extra data too large");
-        pdpVerifier.addPieces(setId, address(0), pieces, tooLargeExtraData);
-
-        // Now actually add piece id 0
-        pdpVerifier.addPieces(setId, address(0), pieces, empty);
-
-        // Test schedulePieceDeletions with too large extra data
-        uint256[] memory pieceIds = new uint256[](1);
-        pieceIds[0] = 0;
-        vm.expectRevert("Extra data too large");
-        pdpVerifier.schedulePieceDeletions(setId, pieceIds, tooLargeExtraData);
-
-        // Test nextProvingPeriod with too large extra data
-        vm.expectRevert("Extra data too large");
-        pdpVerifier.nextProvingPeriod(setId, vm.getBlockNumber() + 10, tooLargeExtraData);
-
-        // Test deleteDataSet with too large extra data
-        vm.expectRevert("Extra data too large");
-        pdpVerifier.deleteDataSet(setId, tooLargeExtraData);
-    }
-
     function testOnlyStorageProviderCanModifyDataSet() public {
         // Setup a piece we can add
         uint256 setId = pdpVerifier.addPieces{value: PDPFees.sybilFee()}(


### PR DESCRIPTION
Closes: #224 

This PR removes the`EXTRA_DATA_MAX_SIZE` limit on extraData across all PDPVerifier functions, implementing option 1 from the discussion in #224.

## Background
The current 2KB limit is insufficient for handling multiple pieces and KVs (Key-Values). After discussion in the daily sync, we aligned on removing the limit entirely since:

1. This limit is a concern for Curio & service contracts
2. There's no technical reason for PDPVerifier to enforce an arbitrary cap