### PR TITLE
fix: changelog v3.1.0 proxy-address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The issue has been resolved with bitmap-based duplicate detection, and these con
 
 **Mainnet:**
 - PDPVerifier Implementation: [0xe2Dc211BffcA499761570E04e8143Be2BA66095f](https://filfox.info/en/address/0xe2Dc211BffcA499761570E04e8143Be2BA66095f)
-- PDPVerifier Proxy: [0xe2Dc211BffcA499761570E04e8143Be2BA66095f](https://filfox.info/en/address/0xe2Dc211BffcA499761570E04e8143Be2BA66095f)
+- PDPVerifier Proxy: [0xBADd0B92C1c71d02E7d520f64c0876538fa2557F](https://filfox.info/en/address/0xBADd0B92C1c71d02E7d520f64c0876538fa2557F)
 
 **Calibnet:**
 - PDPVerifier Implementation: [0x2355Cb19BA1eFF51673562E1a5fc5eE292AF9D42](https://calibration.filfox.info/en/address/0x2355Cb19BA1eFF51673562E1a5fc5eE292AF9D42)


### PR DESCRIPTION
Noticed this copy+paste fumble in the changelog - i.e same proxy and implementation address. The proxy-address for the Mainnet v3.1.0 contract is: 0xBADd0B92C1c71d02E7d520f64c0876538fa2557F. Ref deploy comment. https://github.com/FilOzone/pdp/pull/229#issuecomment-3449832835