### PR TITLE
fix: set default CHALLENGE_FINALITY in deployment scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 RPC_URL ?=
 KEYSTORE ?=
 PASSWORD ?=
-CHALLENGE_FINALITY ?=
 
 # Default target
 .PHONY: default

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,6 +4,12 @@ A place for all tools related to running and developing the PDP contracts. When 
 
 ## Deployment Scripts
 
+| Network     | CHALLENGE_FINALITY |
+|-------------|-------------------|
+| Mainnet     | 150 epochs        |
+| Calibration | 10 epochs         |
+| Devnet      | 10 epochs         |
+
 ### deploy-devnet.sh
 Deploys PDPVerifier to a local filecoin devnet. Assumes lotus binary is in path and local devnet is running with eth API enabled. The keystore will be funded automatically from lotus default address.
 

--- a/tools/deploy-calibnet.sh
+++ b/tools/deploy-calibnet.sh
@@ -17,10 +17,8 @@ if [ -z "$KEYSTORE" ]; then
   exit 1
 fi
 
-if [ -z "$CHALLENGE_FINALITY" ]; then
-  echo "Error: CHALLENGE_FINALITY is not set"
-  exit 1
-fi
+# Calibration testnet uses 10 epochs (vs 150 on mainnet)
+CHALLENGE_FINALITY=10
 
 ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
 echo "Deploying PDP verifier from address $ADDR"

--- a/tools/deploy-devnet.sh
+++ b/tools/deploy-devnet.sh
@@ -37,8 +37,11 @@ echo "PDP verifier implementation deployed at: $VERIFIER_IMPLEMENTATION_ADDRESS"
 
 NONCE=$(expr $NONCE + "1")
 
+# Devnet uses 10 epochs (same as Calibration testnet)
+CHALLENGE_FINALITY=10
+
 echo "Deploying PDP verifier proxy"
-INIT_DATA=$(cast calldata "initialize(uint256)" 150)
+INIT_DATA=$(cast calldata "initialize(uint256)" $CHALLENGE_FINALITY)
 PDP_VERIFIER_ADDRESS=$(forge create --rpc-url "$RPC_URL" --keystore "$KEYSTORE" --password "$PASSWORD" --nonce $NONCE --broadcast src/ERC1967Proxy.sol:MyERC1967Proxy --constructor-args $VERIFIER_IMPLEMENTATION_ADDRESS $INIT_DATA | grep "Deployed to" | awk '{print $3}')
 echo "PDP verifier deployed at: $PDP_VERIFIER_ADDRESS"
 

--- a/tools/deploy-mainnet.sh
+++ b/tools/deploy-mainnet.sh
@@ -17,8 +17,8 @@ if [ -z "$KEYSTORE" ]; then
   exit 1
 fi
 
-# CHALLENGE_FINALITY should always be 150 in production
-CHALLENGE_FINALITY=150 
+# Mainnet uses 150 epochs (vs 10 on Calibration testnet)
+CHALLENGE_FINALITY=150
 
 ADDR=$(cast wallet address --keystore "$KEYSTORE" --password "$PASSWORD")
 echo "Deploying PDP verifier from address $ADDR"


### PR DESCRIPTION
Closes: #216 

Sets the agreed-upon `CHALLENGE_FINALITY` deployment parameters directly in the deploy scripts, matching what is currently deployed on mainnet and calibnet.